### PR TITLE
UWP restricted API fix

### DIFF
--- a/gdal/gcore/gdalclientserver.cpp
+++ b/gdal/gcore/gdalclientserver.cpp
@@ -438,7 +438,9 @@ CPL_UNUSED
     const char* pszCWD)
 {
 #ifdef WIN32
+#ifndef RTC_WINDOWS_UNIVERSAL
     SetCurrentDirectory(pszCWD);
+#endif
 #else
     if(chdir(pszCWD) != 0)
         fprintf(stderr, "chdir(%s) failed\n", pszCWD);/*ok*/
@@ -452,7 +454,9 @@ CPL_UNUSED
 static void MyChdirRootDirectory()
 {
 #ifdef WIN32
+#ifndef RTC_WINDOWS_UNIVERSAL
     SetCurrentDirectory("C:\\");
+#endif
 #else
     CPLAssert(chdir("/") == 0);
 #endif


### PR DESCRIPTION
Removes a call to `SetCurrentDirectory` which evaluates to `SetCurrentDirectoryA` an API not supported on the UWP platform (only the Unicode SetCurrentDirectoryW). This code isn't used by UWP anyway, so just excluding it from the compilation.

