### PR TITLE
GDALDestroy(): no longer call it automatically on GCC/CLang (non-MSVC…

### DIFF
--- a/gdal/gcore/gdaldllmain.cpp
+++ b/gdal/gcore/gdaldllmain.cpp
@@ -56,9 +56,14 @@ void CPLFinalizeTLS();
  * This function calls GDALDestroyDriverManager() and OGRCleanupAll() and
  * finalize Thread Local Storage variables.
  *
- * This function should *not* usually be explicitly called by application code
- * if GDAL is dynamically linked, since it is automatically called through
+ * Prior to GDAL 2.4.0, this function should normally be explicitly called by
+ * application code if GDAL is dynamically linked (but that does not hurt),
+ * since it was automatically called through
  * the unregistration mechanisms of dynamic library loading.
+ *
+ * Since GDAL 2.4.0, this function may be called by application code, since
+ * it is no longer called automatically, on non-MSVC builds, due to ordering
+ * problems with respect to automatic destruction of global C++ objects.
  *
  * Note: no GDAL/OGR code should be called after this call!
  *
@@ -96,8 +101,7 @@ void GDALDestroy(void)
 /************************************************************************/
 #ifdef __GNUC__
 
-static void GDALInitialize(void) __attribute__ ((constructor)) ;
-static void GDALDestructor(void) __attribute__ ((destructor)) ;
+static void GDALInitialize() __attribute__ ((constructor)) ;
 
 /************************************************************************/
 /* Called when GDAL is loaded by loader or by dlopen(),                 */
@@ -113,20 +117,6 @@ static void GDALInitialize(void)
     if( pszLocale )
         CPLsetlocale( LC_ALL, pszLocale );
 #endif
-}
-
-/************************************************************************/
-/* Called when GDAL is unloaded by loader or by dlclose(),              */
-/* and before dlclose() returns.                                        */
-/************************************************************************/
-
-static void GDALDestructor(void)
-{
-    if( bGDALDestroyAlreadyCalled )
-        return;
-    if( !CPLTestBool(CPLGetConfigOption("GDAL_DESTROY", "YES")) )
-        return;
-    GDALDestroy();
 }
 
 #endif // __GNUC__


### PR DESCRIPTION
For issue : https://devtopia.esri.com/runtimecore/c_api/issues/11615

vTest 3rdparty : http://runtime-test.esri.com:8080/view/vTest/job/3rdparty_vtest_interface/247/downstreambuildview/



…) builds

Experiments have shown that a __attribute__((destructor )) function is called
*AFTER* the destructor of static C++ objects. Which is prone to crash is
code called by this destructor function then uses those C++ objects.
There could have been a solution by making the destructor function a C++
object itself and playing with gcc __attribute__((init_priority(XXXX))),
unfortunately the destructor of static C++ objects in functions/methods
is always called before the destructor of objects with explicit priority,
so there is no workaround.

With MSVC, apparently according to
https://stackoverflow.com/questions/4496233/which-is-called-first-dllmain-or-global-static-object-constructor
DllMain(DLL_PROCESS_DETACH) is called before C++ object destruction,
so it seems safe to keep it.

<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
