### PR TITLE
3rdparty: change jpeg to jpeg-turbo

### DIFF
--- a/gdal.lua
+++ b/gdal.lua
@@ -1051,7 +1051,7 @@ project "gdal"
     _3RDPARTY_DIR .. "/gdal/gdal/ogr/ogrsf_frmts/sqlite",
     _3RDPARTY_DIR .. "/gdal/gdal/port",
     _3RDPARTY_DIR .. "/giflib",
-    _3RDPARTY_DIR .. "/jpeg",
+    _3RDPARTY_DIR .. "/libjpeg-turbo",
     _3RDPARTY_DIR .. "/kakadu/include",
     _3RDPARTY_DIR .. "/libexpat/expat/lib",
     _3RDPARTY_DIR .. "/libtiff/libtiff",


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtime/home-one/issues/470
Updating `gdal`'s include paths to point to the newly-installed `jpeg-turbo` library. 

Please review: @chri7325