### PR TITLE
docs: Add Esri specific information for gdal usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 GDAL - Geospatial Data Abstraction Library
 ====
+This fork of GDAL is used by the ArcGIS runtime SDKs product line exclusively. The ArcGIS Pro product line uses a custom
+internal version of GDAL for each release. For more information on ArcGIS Pro's gdal, please find the appropriate
+[documentation](https://www.arcgis.com/home/search.html?t=content&q=tags%3A%22GDAL%22&start=1&num=20&focus=applications)
 
 [![Build Status](https://travis-ci.com/OSGeo/gdal.svg?branch=master)](https://travis-ci.com/OSGeo/gdal)
 [![Build status](https://ci.appveyor.com/api/projects/status/jtwx0pcr0y01i17p/branch/master?svg=true)](https://ci.appveyor.com/project/OSGeo/gdal)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 GDAL - Geospatial Data Abstraction Library
 ====
-This fork of GDAL is used by the ArcGIS runtime SDKs product line exclusively. The ArcGIS Pro product line uses a custom
-internal version of GDAL for each release. For more information on ArcGIS Pro's gdal, please find the appropriate
-[documentation](https://www.arcgis.com/home/search.html?t=content&q=tags%3A%22GDAL%22&start=1&num=20&focus=applications)
+This fork of GDAL is used by the ArcGIS Runtime SDKs product line exclusively, and is independent of the ArcGIS Pro
+product. For more information on ArcGIS Pro's gdal, see the [documentation](https://www.arcgis.com/home/search.html?t=content&q=tags%3A%22GDAL%22&start=1&num=20&focus=applications)
 
 [![Build Status](https://travis-ci.com/OSGeo/gdal.svg?branch=master)](https://travis-ci.com/OSGeo/gdal)
 [![Build status](https://ci.appveyor.com/api/projects/status/jtwx0pcr0y01i17p/branch/master?svg=true)](https://ci.appveyor.com/project/OSGeo/gdal)


### PR DESCRIPTION
Adds requested notes on runtime's usage of GDAL vs Pro's