### PR TITLE
Silence a very specific warning as error for winuwp x64

### DIFF
--- a/gdal.lua
+++ b/gdal.lua
@@ -1503,6 +1503,10 @@ project "gdal"
         intel_intrinsic_defines,
       }
 
+      buildoptions {
+        "/wd4789", -- Silences buffer overrun warning which causes errors during LTCG with Ob3 optimizations on
+      }
+
     -- -------------------------------------------------------------
     -- configuration { "winuwp_debug","ARM" }
     -- -------------------------------------------------------------


### PR DESCRIPTION
RTC uses Ob3 inline expansions to get more performance. Using this
optimization has exposed an error during LTCG that was not there before.

gdal\gdal\gcore\rasterio.cpp(3167): error C4789: buffer 'nVal' of size 8 bytes will be overrun; 16 bytes will be written starting at offset 0

This warning as error might be a serious problem but for now, ignore
the warning as it has yet to create an issue.

Issue: https://devtopia.esri.com/runtimecore/c_api/issues/12879
vTest 3rdparty: http://runtime-test.esri.com:8080/view/vTest/job/vtest-3rdparty_libraries-winuwp/392/console
vTest RTC: http://runtime-test.esri.com:8080/view/vTest/job/vtest-runtimecore-winuwp/9218/console