### PR TITLE
vs: Update the _MSC_VER ceiling to the latest compiler

### DIFF
--- a/gdal/frmts/mrsid/lt_platform.h
+++ b/gdal/frmts/mrsid/lt_platform.h
@@ -65,7 +65,7 @@
 
    #define LT_DEPRECATED(NEW)
 
-#elif defined(_MSC_VER) &&  (1300 <= _MSC_VER && _MSC_VER <= 1921)
+#elif defined(_MSC_VER) &&  (1300 <= _MSC_VER && _MSC_VER <= 1926)
    #define LT_COMPILER_MS 1
    #if _MSC_VER < 1400
       #define LT_COMPILER_MS7 1


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/379