### PR TITLE
arch: Add macos arm64 for neon instructions

### DIFF
--- a/gdal.lua
+++ b/gdal.lua
@@ -1134,6 +1134,17 @@ end
 if (_PLATFORM_MACOS) then
   defines {
     cocoa_defines,
+  }
+
+  configuration { "ARM64" }
+
+  defines {
+    neon_defines,
+  }
+
+  configuration { "x64" }
+
+  defines {
     intel_intrinsic_defines,
   }
 end


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/1000

Allows macOS arm64 to build as it needs neon intrinsics and cannot use intel intrinsics