### PR TITLE
windows: Use the UWP codepath for Desktop

### DIFF
--- a/gdal/frmts/vrt/vrtderivedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtderivedrasterband.cpp
@@ -459,7 +459,7 @@ static bool LoadPythonAPI()
         }
     }
 
-#elif defined(WIN32) && !defined(RTC_WINDOWS_UNIVERSAL)
+#elif defined(WIN32) && !defined(RTC_WINDOWS_FAMILY)
 
     // First try in the current process in case the python symbols would
     // be already loaded


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/1683

@bweather this PR removes a codepath that uses the banned API K32EnumProcessModules for Desktop. We do this for WinUWP but this just extends it to desktop. The function here is to load up a PythonAPI, which we don't use so this PR should be benign.