### PR TITLE
arch: Add additional includes needed to build mrsid

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -18,6 +18,8 @@ class GDALConan(ConanFile):
         relative = "3rdparty/gdal/"
 
         # headers
+        self.copy("*.h*", src=base + "gdal/frmts", dst=relative + "gdal/frmts", excludes=("*.html", "*.in", "*.vc"))
+        self.copy("*.inc", src=base + "gdal/frmts", dst=relative + "gdal/frmts")
         self.copy("*.h*", src=base + "gdal/gcore", dst=relative + "gdal/gcore", excludes=("*.html", "*.in", "*.vc"))
         self.copy("*.h*", src=base + "gdal/ogr", dst=relative + "gdal/ogr", excludes=("*.html", "*.in", "*.vc"))
         self.copy("*.h*", src=base + "gdal/port", dst=relative + "gdal/port", excludes=("*.html", "*.in", "*.vc"))


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/2602

The mrsid library requires a few more includes to allow mrsid to be built using conan packages.