### PR TITLE
arch: Use openjpeg instead of Kakadu for JPEG2000

### DIFF
--- a/gdal.lua
+++ b/gdal.lua
@@ -59,7 +59,7 @@ defines {
   "FRMT_iso8211",
   -- "FRMT_jaxapalsar",
   -- "FRMT_jdem",
-  "FRMT_jp2kak",
+  -- "FRMT_jp2kak",
   "FRMT_jpeg",
   -- "FRMT_jpipkak",
   -- "FRMT_kmlsuperoverlay",
@@ -73,6 +73,7 @@ defines {
   -- "FRMT_ngsgeoid",
   "FRMT_nitf",
   -- "FRMT_northwood",
+  "FRMT_openjpeg",
   -- "FRMT_ozi",
   -- "FRMT_pdf",
   -- "FRMT_pds",
@@ -187,7 +188,6 @@ includedirs {
   _3RDPARTY_DIR .. "/gdal/gdal/ogr/ogrsf_frmts/sqlite",
   _3RDPARTY_DIR .. "/gdal/gdal/port",
   _3RDPARTY_DIR .. "/giflib",
-  _3RDPARTY_DIR .. "/kakadu/include",
   _3RDPARTY_DIR .. "/libexpat/expat/lib",
   _3RDPARTY_DIR .. "/libjpeg-turbo",
   _3RDPARTY_DIR .. "/libpng",
@@ -195,6 +195,7 @@ includedirs {
   _3RDPARTY_DIR .. "/mrsid/mrsid-source-sdk/common",
   _3RDPARTY_DIR .. "/mrsid/mrsid-source-sdk/mrsid",
   _3RDPARTY_DIR .. "/mrsid/mrsid-source-sdk/utils",
+  _3RDPARTY_DIR .. "/openjpeg/src/lib/openjp2",
   _3RDPARTY_DIR .. "/sqlite",
   _3RDPARTY_DIR .. "/zlib-ng",
 }
@@ -370,7 +371,7 @@ files {
   "gdal/frmts/iso8211/ddfutils.cpp",
   -- "gdal/frmts/jaxapalsar/jaxapalsardataset.cpp",
   -- "gdal/frmts/jdem/jdemdataset.cpp",
-  "gdal/frmts/jp2kak/jp2kakdataset.cpp",
+  -- "gdal/frmts/jp2kak/jp2kakdataset.cpp",
   "gdal/frmts/jpeg/jpgdataset.cpp",
   "gdal/frmts/jpeg/vsidataio.cpp",
   -- "gdal/frmts/jpipkak/jpipkakdataset.cpp",
@@ -404,6 +405,7 @@ files {
   -- "gdal/frmts/northwood/grcdataset.cpp",
   -- "gdal/frmts/northwood/grddataset.cpp",
   -- "gdal/frmts/northwood/northwood.cpp",
+  "gdal/frmts/openjpeg/openjpegdataset.cpp",
   -- "gdal/frmts/ozi/ozidataset.cpp",
   -- "gdal/frmts/pdf/ogrpdflayer.cpp",
   -- "gdal/frmts/pdf/pdfcreatecopy.cpp",
@@ -1036,17 +1038,9 @@ files {
   "gdal/port/cpl_xml_validate.cpp",
 }
 
-local neon_defines = {
-  "KDU_NEON_INTRINSICS", -- kakadu
-}
-
 local intel_intrinsic_defines = {
   "HAVE_SSE_AT_COMPILE_TIME", -- gdal
   "HAVE_SSSE3_AT_COMPILE_TIME",
-  "KDU_NO_AVX", -- kakadu
-  "KDU_NO_AVX2",
-  "KDU_NO_SSE4",
-  "KDU_X86_INTRINSICS",
 }
 
 local cocoa_defines = {
@@ -1054,24 +1048,8 @@ local cocoa_defines = {
 }
 
 if (_PLATFORM_ANDROID) then
-  defines {
-    "KDU_NO_THREADS", -- Android has very limited pthread support for our platforms.  Revisit later
-  }
-
   buildoptions {
     "-Wno-error=implicit-function-declaration", -- turn off clang 16+ warning that turned to error for ISO 99 calls
-  }
-
-  configuration { "*arm64*" }
-
-  defines {
-    "KDU_NO_NEON", -- neon intrinsic vqrdmlahq_s16 not available for arm64. Revisit later.
-  }
-
-  configuration { "*armv7*" }
-
-  defines {
-    "KDU_NO_NEON", -- neon intrinsic vcvtnq_s32_f32 not available for armv7. Revisit later.
   }
 
   configuration { "*x64*" }
@@ -1096,12 +1074,6 @@ if (_PLATFORM_IOS) then
     "-Wno-error=implicit-function-declaration", -- turn off clang 16+ warning that turned to error for ISO 99 calls
   }
 
-  configuration { "*arm64*" }
-
-  defines {
-    "KDU_NO_NEON", -- neon intrinsics for arm64 crash the compiler. Revisit later
-  }
-
   configuration { "*x64*" }
 
   defines {
@@ -1112,12 +1084,6 @@ end
 if (_PLATFORM_LINUX) then
   buildoptions {
     "-Wno-error=implicit-function-declaration", -- turn off clang 16+ warning that turned to error for ISO 99 calls
-  }
-
-  configuration { "ARM64" }
-
-  defines {
-    "KDU_NO_NEON", -- neon intrinsics for linux arm64 are not supported
   }
 
   configuration { "x64" }
@@ -1136,12 +1102,6 @@ if (_PLATFORM_MACOS) then
     "-Wno-error=implicit-function-declaration", -- turn off clang 16+ warning that turned to error for ISO 99 calls
   }
 
-  configuration { "ARM64" }
-
-  defines {
-    neon_defines,
-  }
-
   configuration { "x64" }
 
   defines {
@@ -1150,12 +1110,6 @@ if (_PLATFORM_MACOS) then
 end
 
 if (_PLATFORM_WINDOWS) then
-  configuration { "ARM64" }
-
-  defines {
-    "KDU_NO_NEON", -- neon intrinsics for Windows is not supported
-  }
-
   configuration { "x64" }
 
   defines {
@@ -1170,12 +1124,6 @@ if (_PLATFORM_WINDOWS) then
 end
 
 if (_PLATFORM_WINUWP) then
-  configuration { "ARM64" }
-
-  defines {
-    "KDU_NO_NEON", -- neon intrinsics for Windows is not supported
-  }
-
   configuration { "x64" }
 
   defines {


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/3232

Migrates GDAL to use openjpeg by enabling the define and files for it and removing the kakadu ones