### PR TITLE
Remove call to free() on realloc failure

### DIFF
--- a/gdal/ogr/ogr_expat.cpp
+++ b/gdal/ogr/ogr_expat.cpp
@@ -73,7 +73,6 @@ static void* OGRExpatRealloc( void *ptr, size_t size )
     CPLError(CE_Failure, CPLE_OutOfMemory,
              "Expat tried to realloc %d bytes. File probably corrupted",
              static_cast<int>(size));
-    free(ptr);
     return nullptr;
 }
 


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtime/common/issues/13841


https://pubs.opengroup.org/onlinepubs/9699919799/functions/realloc.html

If there is not enough available memory, realloc() shall return a null pointer [CX] [Option Start]  and set errno to [ENOMEM]. [Option End]  If realloc() returns a null pointer [CX] [Option Start]  and errno has been set to [ENOMEM], [Option End]  the memory referenced by ptr shall not be changed.

vTest 3rdpary: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/959/downstreambuildview/

vTest: RTC: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/22500/downstreambuildview/
