### PR TITLE
Cherry-pick fix for CVE-2019-17545: Remove call to free() on realloc() failure

### DIFF
--- a/gdal/ogr/ogr_expat.cpp
+++ b/gdal/ogr/ogr_expat.cpp
@@ -73,7 +73,6 @@ static void* OGRExpatRealloc( void *ptr, size_t size )
     CPLError(CE_Failure, CPLE_OutOfMemory,
              "Expat tried to realloc %d bytes. File probably corrupted",
              static_cast<int>(size));
-    free(ptr);
     return nullptr;
 }
 


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtime/common/issues/13916

3rdpary: https://runtime-rtc.esri.com/view/Release/job/100.15.5/view/vTest/job/vtest/job/3rdparty-interface/87/downstreambuildview/

RTC: https://runtime-rtc.esri.com/view/Release/job/100.15.5/view/vTest/job/vtest/job/runtimecore-interface/768/downstreambuildview/
