### PR TITLE
Fix illegal qualified name in member declaration

### DIFF
--- a/gdal/port/cpl_safemaths.hpp
+++ b/gdal/port/cpl_safemaths.hpp
@@ -118,11 +118,11 @@ inline CPLSafeInt<unsigned> CPLSM_TO_UNSIGNED(GUInt64 x);
 class CPLMSVCSafeIntException : public msl::utilities::SafeIntException
 {
 public:
-    static void CPLMSVCSafeIntException::SafeIntOnOverflow()
+    static void SafeIntOnOverflow()
     {
         throw CPLSafeIntOverflow();
     }
-    static void CPLMSVCSafeIntException::SafeIntOnDivZero()
+    static void SafeIntOnDivZero()
     {
         throw CPLSafeIntOverflowDivisionByZero();
     }


### PR DESCRIPTION
## What does this PR do?

Fix illegal qualified name in member declaration in order to compile with C++ 20.

## What are related issues/pull requests?

Issue: https://devtopia.esri.com/runtime/runtimecore-code-council/issues/156

Build with C++ 20 enabled branch: https://devtopia.esri.com/3rdparty/architecture/tree/chri7325/c++20
vTest: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1014/downstreambuildview/

Build without C++ enabled branch:
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1015/downstreambuildview/
