### PR TITLE
Expose flag to determine if PDFDataset coordinates are in GCS

### DIFF
--- a/gdal/frmts/pdf/gdal_pdf.h
+++ b/gdal/frmts/pdf/gdal_pdf.h
@@ -204,6 +204,9 @@ class PDFDataset final: public GDALPamDataset
     int          bInfoDirty;
     int          bXMPDirty;
 
+    bool        isGeoTransformTargetingGCS = false;
+
+
     std::bitset<PDFLIB_COUNT> bUseLib;
 #ifdef HAVE_POPPLER
     PDFDoc*      poDocPoppler;
@@ -358,6 +361,7 @@ private:
 
     virtual const char* GetProjectionRef() override;
     virtual CPLErr GetGeoTransform( double * ) override;
+    virtual bool        GetIsGeoTransformTargetingGCS() const override;
 
     virtual CPLErr      SetProjection(const char* pszWKTIn) override;
     virtual CPLErr      SetGeoTransform(double* padfGeoTransform) override;

--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -6372,13 +6372,17 @@ int PDFDataset::ParseMeasure(GDALPDFObject* poMeasure,
     /* ISO 32000 supplement spec, but in (northing, easting). Adobe reader is able to understand that, */
     /* so let's also try to do it with a heuristics. */
 
-    int bReproject = TRUE;
+    int bReproject = FALSE;
     if (oSRS.IsProjected() &&
         (fabs(adfGPTS[0]) > 91 || fabs(adfGPTS[2]) > 91 || fabs(adfGPTS[4]) > 91 || fabs(adfGPTS[6]) > 91 ||
          fabs(adfGPTS[1]) > 361 || fabs(adfGPTS[3]) > 361 || fabs(adfGPTS[5]) > 361 || fabs(adfGPTS[7]) > 361))
     {
         CPLDebug("PDF", "GPTS coordinates seems to be in (northing, easting), which is non-standard");
-        bReproject = FALSE;
+    }
+    else
+    {
+        // this is the standard (lat, long) format, so the transform will be targeting a GCS
+        isGeoTransformTargetingGCS = true;
     }
 
     OGRCoordinateTransformation* poCT = nullptr;
@@ -6503,6 +6507,11 @@ CPLErr PDFDataset::GetGeoTransform( double * padfTransform )
     memcpy(padfTransform, adfGeoTransform, 6 * sizeof(double));
 
     return( (bGeoTransformValid) ? CE_None : CE_Failure );
+}
+
+bool PDFDataset::GetIsGeoTransformTargetingGCS() const
+{
+    return isGeoTransformTargetingGCS;
 }
 
 /************************************************************************/

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -511,6 +511,7 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     virtual CPLErr SetProjection( const char * pszProjection );
 
     virtual CPLErr GetGeoTransform( double * padfTransform );
+    virtual bool GetIsGeoTransformTargetingGCS() const;
     virtual CPLErr SetGeoTransform( double * padfTransform );
 
     virtual CPLErr        AddBand( GDALDataType eType,

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -967,6 +967,11 @@ CPLErr GDALDataset::GetGeoTransform( double * padfTransform )
     return CE_Failure;
 }
 
+bool GDALDataset::GetIsGeoTransformTargetingGCS() const
+{
+    return false;
+}
+
 /************************************************************************/
 /*                        GDALGetGeoTransform()                         */
 /************************************************************************/


### PR DESCRIPTION
## What does this PR do?
Since we are skipping reprojection using PROJ, the coordinates coming from the measure dictionary of a PDF were usually still in (lat, long) which was propogated to the geotransform, while we expected the coordinates to be in a PCS. Due to this, I added a boolean property that returns true when the geotransform coordinates are still in a GCS.

Since this is the only change needed, I reverted the below commits and re-added the flag to skip projection up front.

- Revert PR https://github.com/Esri/gdal/pull/38
- Revert commit [cb33d968e62ebbd70386769c6a89e2607c7ba519](https://github.com/Esri/gdal/commit/cb33d968e62ebbd70386769c6a89e2607c7ba519)


## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
