### PR TITLE
Allow projecting GCPs when geotransform is targeting a GCS

### DIFF
--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -6554,6 +6554,7 @@ int PDFDataset::ParseMeasure(GDALPDFObject* poMeasure,
         bReproject = FALSE;
     }
 
+    // Bypass reprojection here as runtime does not use PROJ
     // OGRCoordinateTransformation* poCT = nullptr;
     // if (bReproject)
     // {
@@ -6584,6 +6585,8 @@ int PDFDataset::ParseMeasure(GDALPDFObject* poMeasure,
         double lon = adfGPTS[2*i+1];
         double x = lon;
         double y = lat;
+
+        // Bypass reprojection here as runtime does not use PROJ
         // if (bReproject)
         // {
         //     if (!poCT->Transform(1, &x, &y, nullptr))

--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -6545,26 +6545,27 @@ int PDFDataset::ParseMeasure(GDALPDFObject* poMeasure,
     /* ISO 32000 supplement spec, but in (northing, easting). Adobe reader is able to understand that, */
     /* so let's also try to do it with a heuristics. */
 
-    int bReproject = FALSE;
+    int bReproject = TRUE;
     if (oSRS.IsProjected() &&
         (fabs(adfGPTS[0]) > 91 || fabs(adfGPTS[2]) > 91 || fabs(adfGPTS[4]) > 91 || fabs(adfGPTS[6]) > 91 ||
          fabs(adfGPTS[1]) > 361 || fabs(adfGPTS[3]) > 361 || fabs(adfGPTS[5]) > 361 || fabs(adfGPTS[7]) > 361))
     {
         CPLDebug("PDF", "GPTS coordinates seems to be in (northing, easting), which is non-standard");
+        bReproject = FALSE;
     }
 
-    OGRCoordinateTransformation* poCT = nullptr;
-    if (bReproject)
-    {
-        poCT = OGRCreateCoordinateTransformation( poSRSGeog, &oSRS);
-        if (poCT == nullptr)
-        {
-            delete poSRSGeog;
-            CPLFree(pszWKT);
-            pszWKT = nullptr;
-            return FALSE;
-        }
-    }
+    // OGRCoordinateTransformation* poCT = nullptr;
+    // if (bReproject)
+    // {
+    //     poCT = OGRCreateCoordinateTransformation( poSRSGeog, &oSRS);
+    //     if (poCT == nullptr)
+    //     {
+    //         delete poSRSGeog;
+    //         CPLFree(pszWKT);
+    //         pszWKT = nullptr;
+    //         return FALSE;
+    //     }
+    // }
 
     GDAL_GCP asGCPS[4];
 
@@ -6583,19 +6584,19 @@ int PDFDataset::ParseMeasure(GDALPDFObject* poMeasure,
         double lon = adfGPTS[2*i+1];
         double x = lon;
         double y = lat;
-        if (bReproject)
-        {
-            if (!poCT->Transform(1, &x, &y, nullptr))
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                        "Cannot reproject (%f, %f)", lon, lat);
-                delete poSRSGeog;
-                delete poCT;
-                CPLFree(pszWKT);
-                pszWKT = nullptr;
-                return FALSE;
-            }
-        }
+        // if (bReproject)
+        // {
+        //     if (!poCT->Transform(1, &x, &y, nullptr))
+        //     {
+        //         CPLError(CE_Failure, CPLE_AppDefined,
+        //                 "Cannot reproject (%f, %f)", lon, lat);
+        //         delete poSRSGeog;
+        //         delete poCT;
+        //         CPLFree(pszWKT);
+        //         pszWKT = nullptr;
+        //         return FALSE;
+        //     }
+        // }
 
         x = ROUND_IF_CLOSE(x);
         y = ROUND_IF_CLOSE(y);
@@ -6611,7 +6612,7 @@ int PDFDataset::ParseMeasure(GDALPDFObject* poMeasure,
     }
 
     delete poSRSGeog;
-    delete poCT;
+    // delete poCT;
 
     if (CPLTestBool(CPLGetConfigOption("PDF_REPORT_GCPS", "YES")) &&
         nGCPCount == 0 &&
@@ -6619,6 +6620,13 @@ int PDFDataset::ParseMeasure(GDALPDFObject* poMeasure,
     {
         nGCPCount = 4;
         pasGCPList = GDALDuplicateGCPs(nGCPCount, asGCPS);
+    }
+
+    if (bReproject)
+    {
+        // GCPS as still in a GCS since projection through PROJ was bypassed
+        // so skip computing the geotransform
+        return TRUE;
     }
 
     if (!GDALGCPsToGeoTransform( 4, asGCPS,


### PR DESCRIPTION
## What does this PR do?
- Allow retrieving the GCPs for geospatial PDFs with a Measure dictionary by persisting them in `pasGCPList` 
- return early before computing the geotransform if the coordinates need reprojection
  -  this is because we bypassed using PROJ to do the projection
  - coordinates in the geotransform will still be targeting a GCS in this case which is not what the consuming code expects

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
