### PR TITLE
Default PDFRasterBand tile size to 256 for all LODs

### DIFF
--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -579,27 +579,27 @@ PDFRasterBand::PDFRasterBand( PDFDataset *poDSIn, int nBandIn,
 
     eDataType = GDT_Byte;
 #if 0
-    if (nResolutionLevel > 0)
+    if( nResolutionLevel > 0 )
     {
         nBlockXSize = 256;
         nBlockYSize = 256;
-        poDSIn->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDSIn->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
     }
-    else if (poDSIn->nBlockXSize)
+    else if( poDSIn->nBlockXSize )
     {
         nBlockXSize = poDSIn->nBlockXSize;
         nBlockYSize = poDSIn->nBlockYSize;
     }
-    else if (poDSIn->GetRasterXSize() < 64 * 1024 * 1024 / poDSIn->GetRasterYSize())
+    else if( poDSIn->GetRasterXSize() < 64 * 1024 * 1024 / poDSIn->GetRasterYSize() )
     {
         nBlockXSize = poDSIn->GetRasterXSize();
         nBlockYSize = 1;
     }
     else
     {
-        nBlockXSize = std::min(256, poDSIn->GetRasterXSize());
-        nBlockYSize = std::min(256, poDSIn->GetRasterYSize());
-        poDSIn->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        nBlockXSize = std::min(1024, poDSIn->GetRasterXSize());
+        nBlockYSize = std::min(1024, poDSIn->GetRasterYSize());
+        poDSIn->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
     }
 #else
     // default to 256 to use uniform block sizes at any LOD for

--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -602,7 +602,7 @@ PDFRasterBand::PDFRasterBand( PDFDataset *poDSIn, int nBandIn,
         poDSIn->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
     }
 #else
-    // default to 256 to use uniform block sizes at any LOD for
+    // default to 256 to use uniform block sizes at any LOD
     nBlockXSize = 256;
     nBlockYSize = 256;
 #endif

--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -578,31 +578,34 @@ PDFRasterBand::PDFRasterBand( PDFDataset *poDSIn, int nBandIn,
     nBand = nBandIn;
 
     eDataType = GDT_Byte;
+#if 0
+    if (nResolutionLevel > 0)
+    {
+        nBlockXSize = 256;
+        nBlockYSize = 256;
+        poDSIn->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    }
+    else if (poDSIn->nBlockXSize)
+    {
+        nBlockXSize = poDSIn->nBlockXSize;
+        nBlockYSize = poDSIn->nBlockYSize;
+    }
+    else if (poDSIn->GetRasterXSize() < 64 * 1024 * 1024 / poDSIn->GetRasterYSize())
+    {
+        nBlockXSize = poDSIn->GetRasterXSize();
+        nBlockYSize = 1;
+    }
+    else
+    {
+        nBlockXSize = std::min(256, poDSIn->GetRasterXSize());
+        nBlockYSize = std::min(256, poDSIn->GetRasterYSize());
+        poDSIn->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    }
+#else
+    // default to 256 to use uniform block sizes at any LOD for
     nBlockXSize = 256;
     nBlockYSize = 256;
-
-    // if( nResolutionLevel > 0 )
-    // {
-    //     nBlockXSize = 256;
-    //     nBlockYSize = 256;
-    //     poDSIn->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
-    // }
-    // else if( poDSIn->nBlockXSize )
-    // {
-    //     nBlockXSize = poDSIn->nBlockXSize;
-    //     nBlockYSize = poDSIn->nBlockYSize;
-    // }
-    // else if( poDSIn->GetRasterXSize() < 64 * 1024 * 1024 / poDSIn->GetRasterYSize() )
-    // {
-    //     nBlockXSize = poDSIn->GetRasterXSize();
-    //     nBlockYSize = 1;
-    // }
-    // else
-    // {
-    //     nBlockXSize = std::min(256, poDSIn->GetRasterXSize());
-    //     nBlockYSize = std::min(256, poDSIn->GetRasterYSize());
-    //     poDSIn->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
-    // }
+#endif
 }
 
 /************************************************************************/

--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -578,29 +578,31 @@ PDFRasterBand::PDFRasterBand( PDFDataset *poDSIn, int nBandIn,
     nBand = nBandIn;
 
     eDataType = GDT_Byte;
+    nBlockXSize = 256;
+    nBlockYSize = 256;
 
-    if( nResolutionLevel > 0 )
-    {
-        nBlockXSize = 256;
-        nBlockYSize = 256;
-        poDSIn->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
-    }
-    else if( poDSIn->nBlockXSize )
-    {
-        nBlockXSize = poDSIn->nBlockXSize;
-        nBlockYSize = poDSIn->nBlockYSize;
-    }
-    else if( poDSIn->GetRasterXSize() < 64 * 1024 * 1024 / poDSIn->GetRasterYSize() )
-    {
-        nBlockXSize = poDSIn->GetRasterXSize();
-        nBlockYSize = 1;
-    }
-    else
-    {
-        nBlockXSize = std::min(1024, poDSIn->GetRasterXSize());
-        nBlockYSize = std::min(1024, poDSIn->GetRasterYSize());
-        poDSIn->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
-    }
+    // if( nResolutionLevel > 0 )
+    // {
+    //     nBlockXSize = 256;
+    //     nBlockYSize = 256;
+    //     poDSIn->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
+    // }
+    // else if( poDSIn->nBlockXSize )
+    // {
+    //     nBlockXSize = poDSIn->nBlockXSize;
+    //     nBlockYSize = poDSIn->nBlockYSize;
+    // }
+    // else if( poDSIn->GetRasterXSize() < 64 * 1024 * 1024 / poDSIn->GetRasterYSize() )
+    // {
+    //     nBlockXSize = poDSIn->GetRasterXSize();
+    //     nBlockYSize = 1;
+    // }
+    // else
+    // {
+    //     nBlockXSize = std::min(256, poDSIn->GetRasterXSize());
+    //     nBlockYSize = std::min(256, poDSIn->GetRasterYSize());
+    //     poDSIn->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
+    // }
 }
 
 /************************************************************************/


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Defaults the tile size to 256 for PDFRasterband. This allows us to default the tile size to 256 in Runtime for all LODs which will increase the rendering performance when zooming.

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
