### PR TITLE
Fix incorrect projection when reading Units from GeoPDF but not Projection parameters

### DIFF
--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -5800,6 +5800,7 @@ int PDFDataset::ParseProjDict(GDALPDFDictionary* poProjDict)
         EQUAL(osProjectionType, "UP") || 
         EQUAL(osProjectionType, "SPCS"))
     {
+        /* Unhandled: LOCAL CARTESIAN, MG (MGRS) */
 
         if (EQUAL(osProjectionType, "UT")) /* UTM */
         {
@@ -5861,8 +5862,6 @@ int PDFDataset::ParseProjDict(GDALPDFDictionary* poProjDict)
 
             return TRUE;
     }
-
-    /* Unhandled: LOCAL CARTESIAN, MG (MGRS) */
 
     else if (EQUAL(osProjectionType, "AC")) /* Albers Equal Area Conic */
     {


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

There was a bug with a GeoPDF following OGC standard, where it was projected in the wrong place. This was using `NAD_1983_StatePlane_Ohio_South_FIPS_3402` projection. It turns out with GeoPDF, if gdal reads a `Unit` section of the `Projection` dictionary, it tries to convert the projection parameters from that unit to meters. 

In many cases, this is fine, as the False easting, false northing, etc are read from the `Projection` dictionary. However, in the case of SPCS (and a few others), the projection parameters are read from EPSG (or directly hardcoded in gdal). Then GDAL expects the units it read from EPSG to be in the same linear units as specified in the projection dictionary (which isnt always the case). It tries to convert from those units to meters, and in some cases its already in meters causing an incorrect transformation.

To fix this, this only reprojects using the units read from the projection dictionary if gdal is already reading the projection parameters from there. If GDAL is getting the projection parameters from EPSG or using its hardcoded values, it will transform from those units to meters.

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
