### PR TITLE
PDFDataset: Fix crash on null reference when exploring layers

### DIFF
--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -3792,6 +3792,8 @@ void PDFDataset::ExploreLayersPdfium(GDALPDFArray* poArray,
     for(int i=0;i<nLength;i++)
     {
         GDALPDFObject* poObj = poArray->Get(i);
+        if (poObj == nullptr)
+            continue;
         if (i == 0 && poObj->GetType() == PDFObjectType_String)
         {
             CPLString osName = PDFSanitizeLayerName(poObj->GetString().c_str());


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
This fixes a crash that can occur when using a pdf containing a null reference in the /Order array (which specifies reading order) for optional content.  This is already fixed in the latest version of gdal, and this fix here just applies the exact same guard that the latest version of gdal uses against this.

When opening this as a PDF dataset, this gets here when trying to read the /Order array to read the layers. With this fix, any null references encountered in the /Order array are now skipped, and the rest of the dataset is read. Note that the `PDFDataset::open()` operation completes successfully, so we will still load it and render it as a blank pdf. However, this behavior is the same as opening in ArcGIS Pro, Adobe, or a PDF browser. 


## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
